### PR TITLE
Compatibility with BSD variants

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -774,9 +774,9 @@ acquire_reader(int64_t want_index_within_archive) {
     archive_read_support_format_raw(a);
     if (archive_read_open_filename(a, g_proc_self_fd_filename, BLOCK_SIZE) !=
         ARCHIVE_OK) {
+      fprintf(stderr, "fuse-archive: could not open %s: %s\n",
+              redact(g_archive_filename), archive_error_string(a));
       archive_read_free(a);
-      fprintf(stderr, "fuse-archive: could not open %s\n",
-              redact(g_archive_filename));
       return nullptr;
     }
     r = std::make_unique<struct reader>(a);
@@ -1208,12 +1208,13 @@ pre_initialize() {
   archive_read_support_format_all(g_initialize_archive);
   archive_read_support_format_raw(g_initialize_archive);
   if (my_archive_read_open(g_initialize_archive) != ARCHIVE_OK) {
+    fprintf(stderr, "fuse-archive: could not open %s: %s\n",
+            redact(g_archive_filename),
+            archive_error_string(g_initialize_archive));
     archive_read_free(g_initialize_archive);
     g_initialize_archive = nullptr;
     g_initialize_archive_entry = nullptr;
     g_initialize_index_within_archive = -1;
-    fprintf(stderr, "fuse-archive: could not open %s\n",
-            redact(g_archive_filename));
     return EXIT_CODE_GENERIC_FAILURE;
   }
 


### PR DESCRIPTION
Hello,

First of all, thank you for this simple but quite robust little program. It's working way better for my needs than archivemount or archivefs. I am using fuse-archive quite extensively on FreeBSD (and possibly soon on macOS using the closed source macFUSE) and had to make some small adaptations for it to work.

- I left some code to print verbose messages on failure in foreground mode
- I don't free() the allocated full path string as doing it in every possible case would modify too much code and the OS will free the heap anyway. If you consider that too much of a bad practice, I am very open to clean it on exit.
- I have not amended the Makefile to change prefix to /usr/local, as having a conditional Makefile compatible both with BSD and GNU variants is burdensome
- fuse-archive is working great if linked with FreeBSD's internal version of libarchive (so.7) (which was made by/for FreeBSD at first), but you may want to install the package to get the latest version (so.13). `pkg install fusefs-libs && kldload fuse` is necessary.
- As this is a small contribution, I have not amended AUTHORS nor CONTRIBUTORS files, but I've signed the Google Individual CLA. Feel free to update those files if you consider it appropriate.