### PR TITLE
Modify test for special files.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1133,7 +1133,7 @@ insert_leaf(struct archive* a,
   }
 
   std::string symlink;
-  mode_t mode = archive_entry_mode(e);
+  auto mode = archive_entry_mode(e);
   if (S_ISLNK(mode)) {
     const char* s = archive_entry_symlink_utf8(e);
     if (!s) {
@@ -1147,9 +1147,10 @@ insert_leaf(struct archive* a,
              redact(pathname.c_str()));
       return 0;
     }
-  } else if (!S_ISREG(mode)) {
-    syslog(LOG_ERR, "irregular non-link file in %s: %s",
-           redact(g_archive_filename), redact(pathname.c_str()));
+
+  } else if (S_ISBLK(mode) || S_ISCHR(mode) || S_ISFIFO(mode) || S_ISSOCK(mode)) {
+    syslog(LOG_ERR, "irregular non-link file (%07o) in %s: %s",
+           mode, redact(g_archive_filename), redact(pathname.c_str()));
     return 0;
   }
 


### PR DESCRIPTION
For some reason the test S_ISREG  fails on regular files.
For example:
**stat /usr/lib/cups/backend/snmp**
  File: /usr/lib/cups/backend/snmp
  Size: 35120     	Blocks: 72         IO Block: 4096   regular file
Device: fd01h/64769d	Inode: 656159      Links: 2
Access: (0755/-rwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2022-06-28 10:10:02.242856283 +0000
Modify: 2020-04-24 14:37:14.000000000 +0000
Change: 2021-12-15 23:29:04.213415906 +0000
 Birth: -
 
 If the above file is stored in tar.gz the S_ISREG(archive_entry_mode(e))  returns FALSE!
  
