### PR TITLE
FreeBSD compatibility

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -147,7 +147,13 @@ std::ostream& operator<<(std::ostream& out, ExitCode const e) {
 // ---- Platform specifics
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+
 #define lseek64 lseek
+
+#ifndef error_t
+typedef int error_t;
+#endif
+
 #endif
 
 // ---- Globals

--- a/src/main.cc
+++ b/src/main.cc
@@ -886,6 +886,8 @@ void CreateCacheFile() {
 
   const std::string cache_dir = GetCacheDir();
 
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
+
   g_cache_fd = open(cache_dir.c_str(), O_TMPFILE | O_RDWR | O_EXCL, 0);
   if (g_cache_fd >= 0) {
     LOG(DEBUG) << "Created anonymous cache file in " << Path(cache_dir);
@@ -901,7 +903,9 @@ void CreateCacheFile() {
   // files with O_TMPFILE. Unfortunately, these filesystems are sometimes used
   // for the /tmp directory. In that case, create a named temp file, and unlink
   // it immediately.
-  assert(errno == ENOTSUP);
+
+#endif
+
   LOG(DEBUG) << "The filesystem of " << Path(cache_dir)
              << " does not support O_TMPFILE";
 


### PR DESCRIPTION
I use fuse-archive on a FreeBSD-based NAS.

fuse-archive currently does not compile on FreeBSD, due to two problems:

- `error_t` is Glibc-specific, but can easily be fixed by a `typedef int error_t;`
- `O_TMPFILE` is not implemented yet. A bug is already open [upstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=283179). In the meantime, we could use a named temp file and unlink it immediately, as described for overlayfs.

A bit off-topic for this PR and I haven't dug yet what causes the warnings, but for information:

- compilation under Linux with `gcc (GCC) 14.2.1 20240910`: successful, no warnings at all
- compilation under Linux with `clang version 19.1.6`: successful, with warning:
```
src/main.cc:1934:25: warning: variable 'entry' set but not used [-Wunused-but-set-variable]
 1934 |     while (Entry* const entry = r.NextEntry()) {
      |                         ^
1 warning generated.
```
- compilation under FreeBSD with `g++14 (FreeBSD Ports Collection) 14.2.0`: successful, with warnings:
```
src/main.cc: In function '{anonymous}::Node* {anonymous}::GetOrCreateDirNode(std::string_view)':
src/main.cc:1586:47: warning: narrowing conversion of '(16384 | (511 & (~ {anonymous}::g_options.{anonymous}::Options::dmask)))' from 'unsigned int' to 'mode_t' {aka 'short unsigned int'} [-Wnarrowing]
 1586 |                               .mode = S_IFDIR | (0777 & ~g_options.dmask),
      |                                               ^
src/main.cc: In function 'void {anonymous}::ProcessEntry(Reader&)':
src/main.cc:1735:39: warning: narrowing conversion of '(((unsigned int)((int)((mode_t)(({anonymous}::FileType)ft)))) | (438 & (~ {anonymous}::g_options.{anonymous}::Options::fmask)))' from 'unsigned int' to 'mode_t' {aka 'short unsigned int'} [-Wnarrowing]
 1735 |       .mode = static_cast<mode_t>(ft) | (0666 & ~g_options.fmask),
      |               ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.cc: In function 'void {anonymous}::BuildTree()':
src/main.cc:1928:36: warning: narrowing conversion of '(16384 | (511 & (~ {anonymous}::g_options.{anonymous}::Options::dmask)))' from 'unsigned int' to 'mode_t' {aka 'short unsigned int'} [-Wnarrowing]
 1928 |       .name = "/", .mode = S_IFDIR | (0777 & ~g_options.dmask), .nlink = 2};
      |                                    ^
```
- compilation under FreeBSD with `g++ (FreeBSD Ports Collection) 13.3.0` (default GCC version at the time): successful, with the same warnings as GCC 14 above
- compilation under FreeBSD with `FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)` (version from the base system of 14.2-RELEASE): unsuccessful, with errors:
```
src/main.cc:1586:39: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'mode_t' (aka 'unsigned short') in initializer list [-Wc++11-narrowing]
 1586 |                               .mode = S_IFDIR | (0777 & ~g_options.dmask),
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/stat.h:272:18: note: expanded from macro 'S_IFDIR'
  272 | #define S_IFDIR  0040000                /* directory */
      |                  ^
src/main.cc:1586:39: note: insert an explicit cast to silence this issue
 1586 |                               .mode = S_IFDIR | (0777 & ~g_options.dmask),
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                       static_cast<mode_t>(               )
/usr/include/sys/stat.h:272:18: note: expanded from macro 'S_IFDIR'
  272 | #define S_IFDIR  0040000                /* directory */
      |                  ^
src/main.cc:1735:15: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'mode_t' (aka 'unsigned short') in initializer list [-Wc++11-narrowing]
 1735 |       .mode = static_cast<mode_t>(ft) | (0666 & ~g_options.fmask),
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/main.cc:1735:15: note: insert an explicit cast to silence this issue
 1735 |       .mode = static_cast<mode_t>(ft) | (0666 & ~g_options.fmask),
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |               static_cast<mode_t>(                               )
src/main.cc:1928:28: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'mode_t' (aka 'unsigned short') in initializer list [-Wc++11-narrowing]
 1928 |       .name = "/", .mode = S_IFDIR | (0777 & ~g_options.dmask), .nlink = 2};
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/stat.h:272:18: note: expanded from macro 'S_IFDIR'
  272 | #define S_IFDIR  0040000                /* directory */
      |                  ^
src/main.cc:1928:28: note: insert an explicit cast to silence this issue
 1928 |       .name = "/", .mode = S_IFDIR | (0777 & ~g_options.dmask), .nlink = 2};
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            static_cast<mode_t>(               )
/usr/include/sys/stat.h:272:18: note: expanded from macro 'S_IFDIR'
  272 | #define S_IFDIR  0040000                /* directory */
      |                  ^
```

PS: I don't do C++ enough (by comparaison to C and other languages) to quick-fix the narrowing static_cast confidently enough myself.
NB: I removed an assert: check on `errno != ENOTSUP` followed immediately by `assert(errno == ENOTSUP)`. But I might be not know C++ enough to be sure that `throw` does not resume the program counter, making the assert more relevant. 