### PR TITLE
close mount_point's parent directory if not needed in cleanup

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -2466,6 +2466,7 @@ int main(int const argc, char** const argv) try {
 
       if (mount_point_specified_by_user) {
         LOG(INFO) << "Using existing mount point " << Path(g_mount_point);
+        close(mount_point_parent_fd);
         break;
       }
 

--- a/test/test.py
+++ b/test/test.py
@@ -69,7 +69,14 @@ def GetTree(root, use_md5=True):
             for entry in os.scandir(path):
                 scan(entry.path, entry.stat(follow_symlinks=False))
 
-    scan(root, os.stat(root, follow_symlinks=False))
+    st = os.stat(root, follow_symlinks=False)
+
+    # On some systems, the mount point is not immediately functional.
+    while st.st_ino == 0:
+        time.sleep(0.1)
+        st = os.stat(root, follow_symlinks=False)
+
+    scan(root, st)
     return result
 
 
@@ -1074,6 +1081,7 @@ def TestBigArchiveRandomOrder(options=[]):
         try:
             logging.debug(f'Mounted archive {zip_path!r} on {mount_point!r}')
 
+            GetTree(mount_point, use_md5=False)
             st = os.statvfs(mount_point)
 
             want_blocks = 10546877
@@ -1088,7 +1096,6 @@ def TestBigArchiveRandomOrder(options=[]):
                     f'Mismatch for st.f_files: got: {st.f_files}, want: {want_inodes}'
                 )
 
-            tree = GetTree(mount_point, use_md5=False)
             fd = os.open(os.path.join(mount_point, 'big.txt'), os.O_RDONLY)
             try:
                 random.seed()
@@ -1134,7 +1141,7 @@ def TestBigArchiveStreamed(options=[]):
         )
         try:
             logging.debug(f'Mounted archive {zip_path!r} on {mount_point!r}')
-            tree = GetTree(mount_point, use_md5=False)
+            GetTree(mount_point, use_md5=False)
             fd = os.open(os.path.join(mount_point, 'big.txt'), os.O_RDONLY)
             try:
                 random.seed()


### PR DESCRIPTION
fuse-archive keeps an open fd to the mountpoint's parent directory

- this fd is never closed explicitly, so it stays open for the whole duration of the mount
- if the mountpoint is specified in the arguments, it is used only once to check that the mountpoint exists and left open anyway

In that case, we could use stat() or access() instead of mkdirat() to check for mountpoint existence, but a simpler fix would be to close mount_point_parent_fd if mount_point_specified_by_user is true
