### PR TITLE
Reorder libarchive format bidders

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1108,21 +1108,13 @@ struct Reader : bi::list_base_hook<LinkMode> {
 
     Check(archive_read_support_filter_all(archive.get()));
 
-    // Prepare the handlers for the recognized archive formats. We don't call
-    // archive_read_support_format_all() because we don't want to handle ZIP
-    // archives in streamable mode. We only handle ZIP archives in seekable
-    // mode.
-    // See https://github.com/libarchive/libarchive/issues/1764.
-    // See https://github.com/libarchive/libarchive/issues/2502.
-    Check(archive_read_support_format_zip_seekable(archive.get()));
+    // Prepare the handlers for the recognized archive formats.
+    // We first install handlers whose heuristic format identification
+    // tests are the fastest and least invasive. If one of them emits
+    // a high enough score, then the subsequent testers will do nothing.
 
-    // The following archive formats are supported by libarchive and tested by
+    // The following archive format is supported by libarchive and tested by
     // fuse-archive's authors.
-    Check(archive_read_support_format_7zip(archive.get()));
-    Check(archive_read_support_format_cab(archive.get()));
-    Check(archive_read_support_format_iso9660(archive.get()));
-    Check(archive_read_support_format_rar(archive.get()));
-    Check(archive_read_support_format_rar5(archive.get()));
     Check(archive_read_support_format_tar(archive.get()));
 
     // The following archive formats are supported by libarchive, but they
@@ -1133,6 +1125,20 @@ struct Reader : bi::list_base_hook<LinkMode> {
     Check(archive_read_support_format_mtree(archive.get()));
     Check(archive_read_support_format_xar(archive.get()));
     Check(archive_read_support_format_warc(archive.get()));
+
+    // More expensive bidders, all supported by libarchive and tested
+    // by fuse-archive's authors.
+    Check(archive_read_support_format_7zip(archive.get()));
+    Check(archive_read_support_format_cab(archive.get()));
+    Check(archive_read_support_format_rar(archive.get()));
+    Check(archive_read_support_format_rar5(archive.get()));
+    Check(archive_read_support_format_iso9660(archive.get()));
+
+    // We don't want to handle ZIP archives in streamable mode.
+    // We only handle ZIP archives in seekable mode.
+    // See https://github.com/libarchive/libarchive/issues/1764.
+    // See https://github.com/libarchive/libarchive/issues/2502.
+    Check(archive_read_support_format_zip_seekable(archive.get()));
 
     // We use the "raw" archive format to read simple compressed files such as
     // "romeo.txt.gz".


### PR DESCRIPTION
Starting from this [line](https://github.com/google/fuse-archive/blob/035c887971c2cac258e4e377c48aab198efbf726/src/main.cc#L1117), multiple calls are made to `archive_read_support_format`.
 
Looking at all the comments in [archive_read_support_format_all.c](https://github.com/libarchive/libarchive/blob/65196fdd1a385f22114f245a9002ee8dc899f2c4/libarchive/archive_read_support_format_all.c#L37), we would benefit from reordering those calls.

Also, we see that `archive_read_support_format_all()` do not "`Check()`" on every bidder like fuse-archive, on the contrary, it `archive_clear_error(a)` before returning always OK.
However, this was done in 2011, bidders may have changed, and keeping the check seems ok.
I've never seen a bidder returning ARCHIVE_WARN, but I would consider not exiting the program on ARCHIVE_WARN at this point. 