### PR TITLE
Free FUSE argument list on exit

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -2563,7 +2563,12 @@ int main(int const argc, char** const argv) try {
 
   EnsureUtf8();
 
+  struct FuseArgsDeleter {
+      void operator()(fuse_args* args) { fuse_opt_free_args(args); }
+  };
+
   fuse_args args = FUSE_ARGS_INIT(argc, argv);
+  std::unique_ptr<fuse_args, FuseArgsDeleter> args_ptr(&args);
   if (fuse_opt_parse(&args, &g_options, g_fuse_opts, &ProcessArg) < 0) {
     LOG(ERROR) << "Cannot parse command line arguments";
     throw ExitCode::GENERIC_FAILURE;


### PR DESCRIPTION
When throwing exceptions (or catching errors - I don't know C++ terminology), memory allocated inside `args` leaks.

In the patch, `args_ptr` is never used but share the same scope as args, so it works as a defer function.

NB: fuse_opt_free_args() is safe to be called on freshly initialised args, on zero-initialised args, on a NULL pointer, and safe to be called multiple times. This code has not changed since 2005, so it has been safe for a long time.
