### PR TITLE
Always run pkg-conf on fuse first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ PKG_CONFIG ?= pkg-config
 
 FUSE_MAJOR_VERSION ?= 3
 
-DEPS = libarchive
-
 ifeq ($(FUSE_MAJOR_VERSION), 3)
-DEPS += fuse3
+DEPS = fuse3
 CXXFLAGS += -DFUSE_USE_VERSION=30
 else ifeq ($(FUSE_MAJOR_VERSION), 2)
-DEPS += fuse
+DEPS = fuse
 CXXFLAGS += -DFUSE_USE_VERSION=26
 endif
+
+DEPS += libarchive
 
 CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ endif
 CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 CXXFLAGS += -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter
-CXXFLAGS += -D_FILE_OFFSET_BITS=64 
 
 ifeq ($(DEBUG), 1)
 CXXFLAGS += -O0 -g


### PR DESCRIPTION
PR #48 was wrong.

in `c++  -DFUSE_USE_VERSION=30 -I/usr/local/include -I/usr/local/include/fuse3`, /usr/local/include/fuse.h (fuse2) took precedence over /usr/local/include/fuse3/fuse.h and the wrong headers were included.