### PR TITLE
Fix signed integer overflow in archive entry offset calculation

### DIFF
--- a/fuse-archive.cc
+++ b/fuse-archive.cc
@@ -2874,9 +2874,15 @@ i64 CacheEntryData(Archive* const a,
       case ARCHIVE_OK:
         assert(offset >= 0);
         assert(dest_offset <= file_start_offset + offset);
-        if (__builtin_add_overflow(file_start_offset, offset, &dest_offset)) {
-          LOG(ERROR) << "CacheEntryData: file_start_offset + offset overflow";
-          return -EIO;
+        {
+          i64 new_dest_offset;
+          if (__builtin_add_overflow(file_start_offset, offset,
+                                     &new_dest_offset) ||
+              __builtin_add_overflow(new_dest_offset,
+                                     static_cast<i64>(len), &new_dest_offset)) {
+            throw ExitCode::INVALID_ARCHIVE_CONTENTS;
+          }
+          dest_offset = file_start_offset + offset;
         }
         last_hole_start = dest_fd.WriteBytesAndSkipHoles(
             std::string_view(static_cast<const char*>(buff), len), dest_offset,
@@ -2893,8 +2899,7 @@ i64 CacheEntryData(Archive* const a,
         // Adjust the cache size if there is a final "hole".
         // See https://github.com/google/fuse-archive/issues/40
         if (__builtin_add_overflow(file_start_offset, offset, &dest_offset)) {
-          LOG(ERROR) << "CacheEntryData: file_start_offset + offset overflow";
-          return -EIO;
+          throw ExitCode::INVALID_ARCHIVE_CONTENTS;
         }
         if (last_hole_start < dest_offset) {
           dest_fd.Truncate(dest_offset);

--- a/fuse-archive.cc
+++ b/fuse-archive.cc
@@ -2873,7 +2873,6 @@ i64 CacheEntryData(Archive* const a,
 
       case ARCHIVE_OK:
         assert(offset >= 0);
-        assert(dest_offset <= file_start_offset + offset);
         {
           i64 new_dest_offset;
           if (__builtin_add_overflow(file_start_offset, offset,
@@ -2894,7 +2893,6 @@ i64 CacheEntryData(Archive* const a,
       case ARCHIVE_EOF:
         assert(len == 0);
         assert(offset >= 0);
-        assert(dest_offset <= file_start_offset + offset);
 
         // Adjust the cache size if there is a final "hole".
         // See https://github.com/google/fuse-archive/issues/40

--- a/fuse-archive.cc
+++ b/fuse-archive.cc
@@ -2874,7 +2874,10 @@ i64 CacheEntryData(Archive* const a,
       case ARCHIVE_OK:
         assert(offset >= 0);
         assert(dest_offset <= file_start_offset + offset);
-        dest_offset = file_start_offset + offset;
+        if (__builtin_add_overflow(file_start_offset, offset, &dest_offset)) {
+          LOG(ERROR) << "CacheEntryData: file_start_offset + offset overflow";
+          return -EIO;
+        }
         last_hole_start = dest_fd.WriteBytesAndSkipHoles(
             std::string_view(static_cast<const char*>(buff), len), dest_offset,
             last_hole_start, on_hole);
@@ -2889,7 +2892,10 @@ i64 CacheEntryData(Archive* const a,
 
         // Adjust the cache size if there is a final "hole".
         // See https://github.com/google/fuse-archive/issues/40
-        dest_offset = file_start_offset + offset;
+        if (__builtin_add_overflow(file_start_offset, offset, &dest_offset)) {
+          LOG(ERROR) << "CacheEntryData: file_start_offset + offset overflow";
+          return -EIO;
+        }
         if (last_hole_start < dest_offset) {
           dest_fd.Truncate(dest_offset);
           if (on_hole) {

--- a/test/make_overflow_offset.py
+++ b/test/make_overflow_offset.py
@@ -4,24 +4,27 @@
 The archive contains two entries:
   1. A 1-byte regular file — causes g_cache_size (file_start_offset) to be 1
      after it is cached.
-  2. A GNU sparse file with a single sparse block at offset (INT64_MAX - 1)
-     and length 1, so realsize = INT64_MAX (a valid int64_t).
+  2. A GNU sparse file with a single data block at offset 100 (small, so the
+     cache write succeeds) but with realsize = INT64_MAX. When libarchive
+     signals end-of-file it reports offset = INT64_MAX (the logical file size).
 
-When fuse-archive processes entry 2 with file_start_offset=1:
-  ARCHIVE_OK path (original code, without the fix):
-    dest_offset = 1 + (INT64_MAX - 1) = INT64_MAX   # no overflow here
-    dest_offset += 1                                  # INT64_MAX + 1 → signed overflow (UB)
+With the unfixed code, the ARCHIVE_EOF branch computes:
+  dest_offset = file_start_offset + offset
+              = 1 + INT64_MAX                 → signed integer overflow (UB)
 
-With the fixed code both additions are validated and
-ExitCode::INVALID_ARCHIVE_CONTENTS is thrown before any overflow occurs.
+Verified with UBSan:
+  runtime error: signed integer overflow: 1 + 9223372036854775807 cannot
+  be represented in type 'long int'
+  fuse-archive aborts with SIGABRT (exit 134).
+
+With the fix applied, __builtin_add_overflow detects the overflow and throws
+ExitCode::INVALID_ARCHIVE_CONTENTS (exit 32) — no crash, no UB.
 
 Usage:
   python3 test/make_overflow_offset.py > /tmp/overflow_offset.tar
-  # Without fix:  triggers UB / potential write to wrong cache offset
-  # With fix:     fuse-archive exits with INVALID_ARCHIVE_CONTENTS
+  fuse-archive /tmp/overflow_offset.tar /mnt/test   # exits 32 with fix, crashes without
 """
 
-import struct
 import sys
 
 INT64_MAX = (1 << 63) - 1  # 0x7FFFFFFFFFFFFFFF
@@ -51,16 +54,15 @@ def checksum_for(header: bytearray) -> int:
 
 
 def regular_file_header(name: bytes, size: int) -> bytes:
-    """Build a POSIX ustar header for a regular file."""
     hdr = bytearray(512)
     hdr[0 : len(name)] = name
     hdr[100:108] = b"0000644\0"
     hdr[108:116] = b"0001750\0"
     hdr[116:124] = b"0001750\0"
     hdr[124:136] = tar_field(size, 12)
-    hdr[136:148] = tar_field(0, 12)       # mtime = 0
-    hdr[148:156] = b"        "            # checksum placeholder
-    hdr[156] = ord("0")                   # regular file
+    hdr[136:148] = tar_field(0, 12)
+    hdr[148:156] = b"        "
+    hdr[156] = ord("0")
     hdr[257:263] = b"ustar\0"
     hdr[263:265] = b"00"
     csum = checksum_for(hdr)
@@ -70,31 +72,24 @@ def regular_file_header(name: bytes, size: int) -> bytes:
 
 def gnu_sparse_header(name: bytes, sparse_offset: int,
                       sparse_len: int, realsize: int) -> bytes:
-    """Build a GNU tar header for a sparse file with one sparse entry."""
     hdr = bytearray(512)
     hdr[0 : len(name)] = name
     hdr[100:108] = b"0000644\0"
     hdr[108:116] = b"0001750\0"
     hdr[116:124] = b"0001750\0"
-    # size field holds the amount of real (non-hole) data on disk = sparse_len
+    # size field = physical (non-hole) bytes on disk
     hdr[124:136] = tar_field(sparse_len, 12)
-    hdr[136:148] = tar_field(0, 12)       # mtime = 0
+    hdr[136:148] = tar_field(0, 12)
     hdr[148:156] = b"        "
-    hdr[156] = ord("S")                   # GNU sparse type
-    hdr[257:265] = b"ustar  \0"           # GNU magic
+    hdr[156] = ord("S")               # GNU sparse type
+    hdr[257:265] = b"ustar  \0"       # GNU magic
     hdr[265:297] = b"root" + b"\0" * 28
     hdr[297:329] = b"root" + b"\0" * 28
-
     # Sparse map at offset 386: sp[0].offset[12] + sp[0].size[12]
     hdr[386:398] = tar_field(sparse_offset, 12)
     hdr[398:410] = tar_field(sparse_len, 12)
-
-    # isextended = 0 (no extension blocks)
-    hdr[482] = 0
-
-    # realsize at offset 483 (the logical file size)
+    hdr[482] = 0                       # isextended = 0
     hdr[483:495] = tar_field(realsize, 12)
-
     csum = checksum_for(hdr)
     hdr[148:156] = f"{csum:06o}\0 ".encode()
     return bytes(hdr)
@@ -104,26 +99,27 @@ def make_poc_tar() -> bytes:
     blocks = bytearray()
 
     # --- Entry 1: 1-byte regular file ---
-    # This causes g_cache_size = 1 after caching, so file_start_offset = 1
-    # for the second entry.
+    # After caching, g_cache_size = 1, so file_start_offset = 1 for entry 2.
     blocks += regular_file_header(b"tiny.txt\0", size=1)
     data = bytearray(512)
     data[0] = ord("X")
     blocks += bytes(data)
 
     # --- Entry 2: GNU sparse file ---
-    # sparse_offset = INT64_MAX - 1, sparse_len = 1, realsize = INT64_MAX
+    # One real byte at a small offset (100) so the cache write succeeds.
+    # realsize = INT64_MAX: libarchive reports offset=INT64_MAX at ARCHIVE_EOF.
     #
-    # With file_start_offset = 1 (from entry 1):
-    #   dest_offset = 1 + (INT64_MAX - 1) = INT64_MAX            [OK]
-    #   dest_offset += 1  -->  INT64_MAX + 1  -->  OVERFLOW (UB)
-    sparse_offset = INT64_MAX - 1
-    sparse_len = 1
-    realsize = INT64_MAX  # = sparse_offset + sparse_len, fits in int64_t
-
-    blocks += gnu_sparse_header(b"sparse.bin\0", sparse_offset, sparse_len, realsize)
+    # Unfixed code at ARCHIVE_EOF:
+    #   dest_offset = file_start_offset + offset
+    #               = 1 + INT64_MAX              → signed integer overflow (UB)
+    blocks += gnu_sparse_header(
+        name=b"sparse.bin\0",
+        sparse_offset=100,
+        sparse_len=1,
+        realsize=INT64_MAX,
+    )
     data2 = bytearray(512)
-    data2[0] = ord("A")   # the 1 real byte
+    data2[0] = ord("A")
     blocks += bytes(data2)
 
     # Two EOF blocks

--- a/test/make_overflow_offset.py
+++ b/test/make_overflow_offset.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Generate a GNU sparse tar that triggers signed integer overflow in CacheEntryData.
+
+The archive contains two entries:
+  1. A 1-byte regular file — causes g_cache_size (file_start_offset) to be 1
+     after it is cached.
+  2. A GNU sparse file with a single sparse block at offset (INT64_MAX - 1)
+     and length 1, so realsize = INT64_MAX (a valid int64_t).
+
+When fuse-archive processes entry 2 with file_start_offset=1:
+  ARCHIVE_OK path (original code, without the fix):
+    dest_offset = 1 + (INT64_MAX - 1) = INT64_MAX   # no overflow here
+    dest_offset += 1                                  # INT64_MAX + 1 → signed overflow (UB)
+
+With the fixed code both additions are validated and
+ExitCode::INVALID_ARCHIVE_CONTENTS is thrown before any overflow occurs.
+
+Usage:
+  python3 test/make_overflow_offset.py > /tmp/overflow_offset.tar
+  # Without fix:  triggers UB / potential write to wrong cache offset
+  # With fix:     fuse-archive exits with INVALID_ARCHIVE_CONTENTS
+"""
+
+import struct
+import sys
+
+INT64_MAX = (1 << 63) - 1  # 0x7FFFFFFFFFFFFFFF
+
+
+def encode_base256(value: int, width: int = 12) -> bytes:
+    """Encode a large integer using GNU tar base-256 (high bit of first byte set)."""
+    result = bytearray(width)
+    result[0] = 0x80
+    for i in range(width - 1, 0, -1):
+        result[i] = value & 0xFF
+        value >>= 8
+    return bytes(result)
+
+
+def tar_field(value: int, width: int) -> bytes:
+    """Encode a tar numeric field; use base-256 for values too large for octal."""
+    if value < 8 ** (width - 1):
+        return f"{value:0{width-1}o}\0".encode()
+    return encode_base256(value, width)
+
+
+def checksum_for(header: bytearray) -> int:
+    h = bytearray(header)
+    h[148:156] = b"        "
+    return sum(h)
+
+
+def regular_file_header(name: bytes, size: int) -> bytes:
+    """Build a POSIX ustar header for a regular file."""
+    hdr = bytearray(512)
+    hdr[0 : len(name)] = name
+    hdr[100:108] = b"0000644\0"
+    hdr[108:116] = b"0001750\0"
+    hdr[116:124] = b"0001750\0"
+    hdr[124:136] = tar_field(size, 12)
+    hdr[136:148] = tar_field(0, 12)       # mtime = 0
+    hdr[148:156] = b"        "            # checksum placeholder
+    hdr[156] = ord("0")                   # regular file
+    hdr[257:263] = b"ustar\0"
+    hdr[263:265] = b"00"
+    csum = checksum_for(hdr)
+    hdr[148:156] = f"{csum:06o}\0 ".encode()
+    return bytes(hdr)
+
+
+def gnu_sparse_header(name: bytes, sparse_offset: int,
+                      sparse_len: int, realsize: int) -> bytes:
+    """Build a GNU tar header for a sparse file with one sparse entry."""
+    hdr = bytearray(512)
+    hdr[0 : len(name)] = name
+    hdr[100:108] = b"0000644\0"
+    hdr[108:116] = b"0001750\0"
+    hdr[116:124] = b"0001750\0"
+    # size field holds the amount of real (non-hole) data on disk = sparse_len
+    hdr[124:136] = tar_field(sparse_len, 12)
+    hdr[136:148] = tar_field(0, 12)       # mtime = 0
+    hdr[148:156] = b"        "
+    hdr[156] = ord("S")                   # GNU sparse type
+    hdr[257:265] = b"ustar  \0"           # GNU magic
+    hdr[265:297] = b"root" + b"\0" * 28
+    hdr[297:329] = b"root" + b"\0" * 28
+
+    # Sparse map at offset 386: sp[0].offset[12] + sp[0].size[12]
+    hdr[386:398] = tar_field(sparse_offset, 12)
+    hdr[398:410] = tar_field(sparse_len, 12)
+
+    # isextended = 0 (no extension blocks)
+    hdr[482] = 0
+
+    # realsize at offset 483 (the logical file size)
+    hdr[483:495] = tar_field(realsize, 12)
+
+    csum = checksum_for(hdr)
+    hdr[148:156] = f"{csum:06o}\0 ".encode()
+    return bytes(hdr)
+
+
+def make_poc_tar() -> bytes:
+    blocks = bytearray()
+
+    # --- Entry 1: 1-byte regular file ---
+    # This causes g_cache_size = 1 after caching, so file_start_offset = 1
+    # for the second entry.
+    blocks += regular_file_header(b"tiny.txt\0", size=1)
+    data = bytearray(512)
+    data[0] = ord("X")
+    blocks += bytes(data)
+
+    # --- Entry 2: GNU sparse file ---
+    # sparse_offset = INT64_MAX - 1, sparse_len = 1, realsize = INT64_MAX
+    #
+    # With file_start_offset = 1 (from entry 1):
+    #   dest_offset = 1 + (INT64_MAX - 1) = INT64_MAX            [OK]
+    #   dest_offset += 1  -->  INT64_MAX + 1  -->  OVERFLOW (UB)
+    sparse_offset = INT64_MAX - 1
+    sparse_len = 1
+    realsize = INT64_MAX  # = sparse_offset + sparse_len, fits in int64_t
+
+    blocks += gnu_sparse_header(b"sparse.bin\0", sparse_offset, sparse_len, realsize)
+    data2 = bytearray(512)
+    data2[0] = ord("A")   # the 1 real byte
+    blocks += bytes(data2)
+
+    # Two EOF blocks
+    blocks += bytes(1024)
+
+    return bytes(blocks)
+
+
+if __name__ == "__main__":
+    sys.stdout.buffer.write(make_poc_tar())


### PR DESCRIPTION
## Security fix

**Signed integer overflow in CacheEntryData** (`fuse-archive.cc`)
The expression `file_start_offset + offset` can overflow when processing a crafted archive with a large `file_start_offset`. Both operands are signed 64-bit values; overflow is undefined behavior and can cause writes to incorrect file positions. Fixed by adding overflow checks using `__builtin_add_overflow` at both locations.